### PR TITLE
Update JAX padding array to use the same number of columns as Vg

### DIFF
--- a/qarray/jax_implementations/helper_functions.py
+++ b/qarray/jax_implementations/helper_functions.py
@@ -29,7 +29,7 @@ def _batched_vmap(f: Callable, Vg: VectorList, n_dot: int, batch_size: int) -> V
             remainder = vg_size % batch_size
             if remainder != 0:
                 N = N + 1
-                Vg = jnp.concatenate([Vg, jnp.zeros((batch_size - remainder, n_dot))], axis=0)
+                Vg = jnp.concatenate([Vg, jnp.zeros((batch_size - remainder, n_gate))], axis=0)
 
             # reshaping into the batches along the first axis
             Vg = Vg.reshape(N, batch_size, n_gate)


### PR DESCRIPTION
I noticed a bug with the JAX implementation. When simulating the `DotArray` class using `model.ground_state_open(vg)`. I received the following error:

```
TypeError: Cannot concatenate arrays with shapes that differ in dimensions other than the one being concatenated: concatenating along dimension 0 for shapes (16384, 3), (3616, 2).
```

I fixed it by modifying the JAX helper function, `_batched_vmap` to pad Vg with the same number of columns as `Vg` (`n_gate`).